### PR TITLE
Disables the fill in button before the story is generated and added adjectives

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import InputField from '@/app/common/components/InputField'
 import AdjectiveInput from '@/app/common/components/AdjectiveInput'
-import { CSSProperties, FormEvent, useState } from 'react'
+import { FormEvent, useState } from 'react'
 
 const systemMessage = `
 You are a professional writer.


### PR DESCRIPTION
Fill in er disabled før en story er generert og valgt adjektiver. La også til en enkel placeholder for input feltet til generate story. 

Formatering gjort av prettier